### PR TITLE
Add optional build-app and build-flags options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@
     # invalidate existing caches.
     # Default: "v1"
     cache-key: ""
+    # Compile application using `mix compile`.
+    # Default: true
+    build-app: true
+    # Additional flags to pass to `mix compile`.
+    # Default: "--all-warnings"
+    build-flags: ""
 ```
 
 ### Basic Usage

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,12 @@ inputs:
       An arbitrary string added to the derived cache key names. Set or change to
       invalidate existing caches.
     default: "v1"
+  build-app:
+    description: Compile application using `mix compile`.
+    default: true
+  build-flags:
+    description: Additional flags to pass to `mix compile`.
+    default: "--all-warnings"
 
 outputs:
   otp-version:
@@ -105,5 +111,6 @@ runs:
       shell: bash
 
     - name: Compile application
-      run: mix compile
+      if: inputs.build-app == 'true'
+      run: mix compile ${{ inputs.build-flags }}
       shell: bash


### PR DESCRIPTION
Draws more options from [felt/ultimate-elixir-ci's Action](https://github.com/felt/ultimate-elixir-ci/blob/main/.github/actions/elixir-setup/action.yml) that I overlooked on v1.0.0.

```yaml
build-app:
  description: Compile application using `mix compile`.
  default: true
build-flags:
  description: Additional flags to pass to `mix compile`.
  default: "--all-warnings"
```